### PR TITLE
Fix: update UST helper provider and event names

### DIFF
--- a/contents/using-lttng/instrumenting/prebuilt-ust-helpers/liblttng-ust-dl.md
+++ b/contents/using-lttng/instrumenting/prebuilt-ust-helpers/liblttng-ust-dl.md
@@ -21,10 +21,10 @@ following tracepoints when preloaded:
     <tbody>
         <tr>
             <td rowspan="2">
-                <code class="no-bg">ust_baddr</code>
+                <code class="no-bg">lttng_ust_dl</code>
             </td>
             <td>
-                <code class="no-bg">push</code>
+                <code class="no-bg">dlopen</code>
             </td>
             <td>
                 <p><code>dlopen()</code> call</p>
@@ -54,7 +54,7 @@ following tracepoints when preloaded:
         </tr>
         <tr>
             <td>
-                <code class="no-bg">pop</code>
+                <code class="no-bg">dlclose</code>
             </td>
             <td>
                 <p><code>dlclose()</code> call</p>

--- a/contents/using-lttng/instrumenting/prebuilt-ust-helpers/liblttng-ust-libc-pthread-wrapper.md
+++ b/contents/using-lttng/instrumenting/prebuilt-ust-helpers/liblttng-ust-libc-pthread-wrapper.md
@@ -21,7 +21,7 @@ The following functions are traceable by `liblttng-ust-libc-wrapper.so`:
     <tbody>
         <tr>
             <td rowspan="6">
-                <code class="no-bg">ust_libc</code>
+                <code class="no-bg">lttng_ust_libc</code>
             </td>
             <td>
                 <code class="no-bg">malloc</code>
@@ -89,7 +89,7 @@ The following functions are traceable by
     <tbody>
         <tr>
             <td rowspan="4">
-                <code class="no-bg">ust_pthread</code>
+                <code class="no-bg">lttng_ust_pthread</code>
             </td>
             <td>
                 <code class="no-bg">pthread_mutex_lock_req</code>


### PR DESCRIPTION
Helpers from LTTng UST, for libdl, libc, and pthread have had their
providers renamed to use a "lttng_" prefix between 2.6 and 2.7. The
libdl helper also had its events renamed from "push" and "pop" to the
more intuitive "dlopen" and "dlclose", respectively.

Signed-off-by: Antoine Busque <abusque@efficios.com>