### PR TITLE
2.9: fix link to GCC's -finstrument-functions

### DIFF
--- a/2.9/lttng-docs-2.9.txt
+++ b/2.9/lttng-docs-2.9.txt
@@ -4133,7 +4133,7 @@ The path:{liblttng-ust-cyg-profile*.so} helpers can add instrumentation
 to the entry and exit points of functions.
 
 man:gcc(1) and man:clang(1) have an option named
-https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html[`-finstrument-functions`]
+https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html[`-finstrument-functions`]
 which generates instrumentation calls for entry and exit to functions.
 The LTTng-UST function tracing helpers,
 path:{liblttng-ust-cyg-profile.so} and


### PR DESCRIPTION
Signed-off-by: Ricardo Nabinger Sanchez <rnsanchez@wait4.org>