### PR TITLE
2.7, 2.8, 2.9: put --live after session name

### DIFF
--- a/2.7/lttng-docs-2.7.txt
+++ b/2.7/lttng-docs-2.7.txt
@@ -6042,7 +6042,7 @@ To use LTTng live:
 --
 [role="term"]
 ----
-lttng create --live my-session
+lttng create my-session --live
 ----
 --
 +

--- a/2.7/lttng-docs-2.7.txt
+++ b/2.7/lttng-docs-2.7.txt
@@ -5150,7 +5150,7 @@ To output LTTng traces to a non-default location:
 --
 [role="term"]
 ----
-lttng create --output=/tmp/some-directory my-session
+lttng create my-session --output=/tmp/some-directory
 ----
 --
 
@@ -6108,7 +6108,7 @@ To take a snapshot:
 --
 [role="term"]
 ----
-lttng create --snapshot my-session
+lttng create my-session --snapshot
 ----
 --
 +

--- a/2.7/lttng-docs-2.7.txt
+++ b/2.7/lttng-docs-2.7.txt
@@ -6208,7 +6208,7 @@ trace data after a system crash:
 --
 [role="term"]
 ----
-lttng create --shm-path=/path/to/shm
+lttng create my-session -shm-path=/path/to/shm
 ----
 --
 

--- a/2.8/lttng-docs-2.8.txt
+++ b/2.8/lttng-docs-2.8.txt
@@ -6654,7 +6654,7 @@ To use LTTng live:
 --
 [role="term"]
 ----
-lttng create --live my-session
+lttng create my-session --live
 ----
 --
 +

--- a/2.8/lttng-docs-2.8.txt
+++ b/2.8/lttng-docs-2.8.txt
@@ -6864,7 +6864,7 @@ trace data after a system crash:
 --
 [role="term"]
 ----
-lttng create --shm-path=/path/to/shm
+lttng create my-session --shm-path=/path/to/shm
 ----
 --
 

--- a/2.8/lttng-docs-2.8.txt
+++ b/2.8/lttng-docs-2.8.txt
@@ -5723,7 +5723,7 @@ To output LTTng traces to a non-default location:
 --
 [role="term"]
 ----
-lttng create --output=/tmp/some-directory my-session
+lttng create my-session --output=/tmp/some-directory
 ----
 --
 
@@ -6721,7 +6721,7 @@ To take a snapshot:
 --
 [role="term"]
 ----
-lttng create --snapshot my-session
+lttng create my-session --snapshot
 ----
 --
 +

--- a/2.9/lttng-docs-2.9.txt
+++ b/2.9/lttng-docs-2.9.txt
@@ -5494,7 +5494,7 @@ To output LTTng traces to a non-default location:
 --
 [role="term"]
 ----
-lttng create --output=/tmp/some-directory my-session
+lttng create my-session --output=/tmp/some-directory
 ----
 --
 
@@ -6506,7 +6506,7 @@ To take a snapshot:
 --
 [role="term"]
 ----
-lttng create --snapshot my-session
+lttng create my-session --snapshot
 ----
 --
 +

--- a/2.9/lttng-docs-2.9.txt
+++ b/2.9/lttng-docs-2.9.txt
@@ -6439,7 +6439,7 @@ To use LTTng live:
 --
 [role="term"]
 ----
-lttng create --live my-session
+lttng create my-session --live
 ----
 --
 +

--- a/2.9/lttng-docs-2.9.txt
+++ b/2.9/lttng-docs-2.9.txt
@@ -6709,7 +6709,7 @@ trace data after a system crash:
 --
 [role="term"]
 ----
-lttng create --shm-path=/path/to/shm
+lttng create my-session --shm-path=/path/to/shm
 ----
 --
 


### PR DESCRIPTION
"--live" have an optional argument. The session name is treated as
"--live" argument returning an error.

Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>