### PR TITLE
Mention stable-2.11 Ubuntu PPA for 2.11 instead of stable-2.10

### DIFF
--- a/2.11/lttng-docs-2.11.txt
+++ b/2.11/lttng-docs-2.11.txt
@@ -1,7 +1,7 @@
 The LTTng Documentation
 =======================
 Philippe Proulx <pproulx@efficios.com>
-v2.11, 2 April 2020
+v2.11, 6 April 2020
 
 
 include::../common/copyright.txt[]
@@ -422,7 +422,7 @@ PPA:
 --
 [role="term"]
 ----
-# apt-add-repository ppa:lttng/stable-2.10
+# apt-add-repository ppa:lttng/stable-2.11
 # apt-get update
 ----
 --


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>