### PR TITLE
2.11, 2.12: fix references to 2.11 regarding new callstack-* contexts

### DIFF
--- a/2.11/lttng-docs-2.11.txt
+++ b/2.11/lttng-docs-2.11.txt
@@ -6293,7 +6293,7 @@ help you solve a problem faster. Examples of context fields are:
   **process priority** of the thread in which the event occurs.
 * The **hostname** of the system on which the event occurs.
 * The Linux kernel and user call stacks (since
-  LTTng{nbsp}11).
+  LTTng{nbsp}2.11).
 * The current values of many possible **performance counters** using
   perf, for example:
 ** CPU cycles, stalled cycles, idle cycles, and the other cycle types.

--- a/2.12/lttng-docs-2.12.txt
+++ b/2.12/lttng-docs-2.12.txt
@@ -6180,7 +6180,7 @@ Examples of context fields are:
   **process priority** of the thread in which the event occurs.
 * The **hostname** of the system on which the event occurs.
 * The Linux kernel and user call stacks (since
-  LTTng{nbsp}11).
+  LTTng{nbsp}2.11).
 * The current values of many possible **performance counters** using
   perf, for example:
 ** CPU cycles, stalled cycles, idle cycles, and the other cycle types.


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>